### PR TITLE
fix: fix the broken URLs links to /bot-qr-code.png

### DIFF
--- a/root/README.md
+++ b/root/README.md
@@ -66,5 +66,5 @@ Here is the whole image for wechaty puppet introduction:
 >
 > Please read the doc before you ask question in the group. We don't welcome any discussion unrelated to wechaty, or you should give a red pocket\(more than 100 RMB\) in the group.
 
-![Wechaty Developers&apos; Home](https://chatie.io/wechaty/images/bot-qr-code.png)
+![Wechaty Developers&apos; Home](https://wechaty.github.io/wechaty/images/bot-qr-code.png)
 

--- a/root/api/contact.md
+++ b/root/api/contact.md
@@ -74,7 +74,7 @@ await contact.say('welcome to wechaty!')
 // 2. send media file to contact
 
 import { FileBox }  from 'file-box'
-const fileBox1 = FileBox.fromUrl('https://chatie.io/wechaty/images/bot-qr-code.png')
+const fileBox1 = FileBox.fromUrl('https://wechaty.github.io/wechaty/images/bot-qr-code.png')
 const fileBox2 = FileBox.fromFile('/tmp/text.txt')
 await contact.say(fileBox1)
 await contact.say(fileBox2)

--- a/root/api/message.md
+++ b/root/api/message.md
@@ -186,7 +186,7 @@ bot
 // 1. send Image
 
   if (/^ding$/i.test(m.text())) {
-    const fileBox = FileBox.fromUrl('https://chatie.io/wechaty/images/bot-qr-code.png')
+    const fileBox = FileBox.fromUrl('https://wechaty.github.io/wechaty/images/bot-qr-code.png')
     await msg.say(fileBox)
   }
 

--- a/root/api/room.md
+++ b/root/api/room.md
@@ -103,7 +103,7 @@ await room.say('Hello world!')
 // 2. Send media file inside Room
 
 import { FileBox }  from 'file-box'
-const fileBox1 = FileBox.fromUrl('https://chatie.io/wechaty/images/bot-qr-code.png')
+const fileBox1 = FileBox.fromUrl('https://wechaty.github.io/wechaty/images/bot-qr-code.png')
 const fileBox2 = FileBox.fromLocal('/tmp/text.txt')
 await room.say(fileBox1)
 await room.say(fileBox2)


### PR DESCRIPTION
Hi. there're several links to `chatie.io` should be changed into `wechaty.github.io`. 

One from markdown to display the `/bot-qr-code.png`, the other three are `FileBox.fromUrl()` to fetch the `/bot-qr-code.png` as possibly send them. 